### PR TITLE
Add link to archived workshop page

### DIFF
--- a/CarpentryCon-2018/Sessions/2018-05-31/11-Breakout-11-Fostering-FAIR-Data-And-Sustainable-Software-Practices/Abstract.md
+++ b/CarpentryCon-2018/Sessions/2018-05-31/11-Breakout-11-Fostering-FAIR-Data-And-Sustainable-Software-Practices/Abstract.md
@@ -9,3 +9,5 @@ Bérénice Batut & Katrin Leinweber
 How can we apply the FAIR principles (Findable, Accessible, Interoperable, Reusable) to the different scientific objects? These objects can be datasets, source code of software or scripts, publications, training materials, etc. In this breakout session we'll introduce the principles and want to discuss with you which best practices and tools fit each purpose. Which differences and commonalities can we observe?
 
 ## [Notes](https://docs.google.com/document/d/1WfxaJQyZDEHZ6DaHJNJAK3dV2pnYSJZDjH_zqUBq4Uw)
+
+## [Experimental TIB workshop informed by this breakout session](https://tibhannover.github.io/2018-07-09-FAIR-Data-and-Software/)


### PR DESCRIPTION
Hi! I realised reecently that I never added the page of the workshop that was informed by this breakout session here. Is it relevant/useful?